### PR TITLE
Add CI workflows and supporting assets

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,133 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Verify AGIALPHA constants
+        run: npm run verify:agialpha
+      - name: Detect ungenerated constants
+        run: npm run compile && git diff --exit-code contracts/Constants.sol
+      - name: Verify module wiring
+        env:
+          TRUFFLE_NETWORK: mainnet
+          MAINNET_RPC_URL: https://cloudflare-eth.com
+          MAINNET_PRIVATE_KEY: 0x0000000000000000000000000000000000000000000000000000000000000001
+        run: npm run wire:verify
+      - name: Run lint
+        run: npm run lint
+      - name: Check formatting
+        run: npm run format -- --check
+      - name: Run tests
+        run: npm test
+      - name: Check module governance
+        run: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/transfer-ownership.ts --new-owner 0x0000000000000000000000000000000000000000
+
+  slither:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - name: Install Node.js dependencies
+        run: npm ci
+      - name: Compile contracts
+        run: npx hardhat compile --force
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Slither
+        run: |
+          pip install slither-analyzer solc-select
+          solc-select install 0.8.25
+          solc-select use 0.8.25
+      - name: Run Slither
+        run: |
+          set -euo pipefail
+          mkdir -p slither-report
+          set +e
+          slither . \
+            --solc-remaps @openzeppelin=node_modules/@openzeppelin/ \
+            --filter-paths node_modules \
+            --compile-force-framework hardhat \
+            --hardhat-ignore-compile \
+            --json slither-report/slither-report.json \
+            --checklist \
+            --fail-high
+          status=$?
+          set -e
+          if [ -f slither-checklist.md ]; then
+            mv slither-checklist.md slither-report/slither-report.md
+          fi
+          exit "$status"
+      - name: Upload Slither report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: slither-report
+          path: slither-report/
+          if-no-files-found: error
+
+  echidna:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Echidna fuzzing campaign
+        run: npm run echidna
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Solidity coverage with threshold gate
+        run: npm run coverage:full
+
+  gas-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+      - name: Run gas snapshot regression check
+        run: npm run gas:check

--- a/echidna/commit-reveal.yaml
+++ b/echidna/commit-reveal.yaml
@@ -1,0 +1,15 @@
+# Echidna configuration for the CommitReveal harness.
+#
+# The harness exercises the commit/reveal flow and maintains an invariant
+# ensuring that the internal nonce accounting never drifts from the number
+# of successful reveals. The fuzzing campaign is configured in assertion
+# mode so that Echidna stops immediately on counterexamples.
+testMode: assertion
+corpusDir: echidna/corpus/commit-reveal
+seed: 1
+
+# Force crytic-compile to use the bundled solc compiler so the Echidna
+# container does not require Foundry's `forge` binary.
+cryticArgs:
+  - --compile-force-framework
+  - solc

--- a/gas-snapshots/commit-reveal.snap
+++ b/gas-snapshots/commit-reveal.snap
@@ -1,0 +1,2 @@
+CommitRevealGas:testCommitGas() (gas: 30880)
+CommitRevealGas:testRevealGas() (gas: 83207)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agijobsv0",
   "version": "1.0.0",
-  "description": "[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)",
+  "description": "[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv2/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobsv2/actions/workflows/ci.yml)",
   "main": "index.js",
   "scripts": {
     "compile": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/generate-constants.ts && npx hardhat compile",

--- a/tools/forge-shim
+++ b/tools/forge-shim
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""A lightweight shim for `forge config --json` used in CI containers.
+
+The Echidna Docker image used by `npm run echidna` does not bundle Foundry's
+`forge` binary, but crytic-compile attempts to call `forge config --json` when a
+`foundry.toml` file is present. This script emulates the subset of the Foundry
+CLI we need so that fuzzing can run without requiring Forge inside the
+container.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+CONFIG_ENV = "FOUNDRY_CONFIG"
+DEFAULT_CONFIG = "foundry.toml"
+
+
+def _parse_value(raw: str) -> Any:
+    """Parse a TOML literal using `ast.literal_eval` with minimal preprocessing.
+
+    The Foundry config we ship only uses primitive literals, arrays and strings.
+    We normalise booleans to their Python equivalents before evaluating the
+    expression. If evaluation fails we fall back to returning a stripped string
+    so the shim behaves defensively.
+    """
+
+    pythonish = re.sub(r"\btrue\b", "True", raw, flags=re.IGNORECASE)
+    pythonish = re.sub(r"\bfalse\b", "False", pythonish, flags=re.IGNORECASE)
+    pythonish = re.sub(r"\bnull\b", "None", pythonish, flags=re.IGNORECASE)
+    try:
+        return ast.literal_eval(pythonish)
+    except (ValueError, SyntaxError):
+        return raw.strip().strip('"\'')
+
+
+def _load_foundry_config(path: Path) -> Dict[str, Any]:
+    config: Dict[str, Any] = {"profile": {}}
+    current: Dict[str, Any] | None = None
+
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1]
+            if section.startswith("profile."):
+                profile_name = section.split(".", 1)[1]
+                current = config["profile"].setdefault(profile_name, {})
+            else:
+                current = None
+            continue
+        if current is None or "=" not in line:
+            continue
+        key, raw_value = [part.strip() for part in line.split("=", 1)]
+        current[key] = _parse_value(raw_value)
+
+    return config
+
+
+def _resolve_config_path() -> Path:
+    location = os.environ.get(CONFIG_ENV, DEFAULT_CONFIG)
+    candidate = Path(location)
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    return candidate
+
+
+def _handle_config(args: list[str]) -> int:
+    if "--help" in args or "-h" in args:
+        print("Usage: forge config [--json]")
+        return 0
+
+    config_path = _resolve_config_path()
+    if not config_path.exists():
+        print(f"forge-shim: config file not found: {config_path}", file=sys.stderr)
+        return 1
+
+    data = _load_foundry_config(config_path)
+    if "--json" in args:
+        print(json.dumps(data))
+    else:
+        for profile, values in data.get("profile", {}).items():
+            print(f"[{profile}]")
+            for key, value in values.items():
+                print(f"{key} = {value}")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) <= 1:
+        print("forge-shim: no arguments provided", file=sys.stderr)
+        return 1
+
+    command, *rest = sys.argv[1:]
+    if command == "--version":
+        print("forge-shim 0.0.1")
+        return 0
+    if command == "config":
+        return _handle_config(rest)
+
+    print(
+        "forge-shim: unsupported command. Only `forge config` is available in this environment.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add the GitHub Actions CI workflows from the v0 repository and adjust the constant check path for the flattened contracts layout
- update the npm badge links to point at MontrealAI/AGIJobsv2 and bring over the Echidna configuration, gas snapshot, and forge shim that the pipelines consume

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2073557c48333b6b34af2ac91b578