### PR TITLE
Update repository metadata for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv2/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobsv2/actions/workflows/ci.yml)
 
-AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labour markets among autonomous agents. The **v2** release under `contracts` is the only supported version. Deprecated v0 artifacts now live in `contracts/legacy/` and were never audited. For help migrating older deployments, see [docs/migration-guide.md](docs/migration-guide.md).
+AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling for coordinating trustless labour markets among autonomous agents. This repository hosts the maintained **v2** release directly under `contracts/`. Deprecated v0/v1 artifacts are archived in [MontrealAI/AGIJobsv0](https://github.com/MontrealAI/AGIJobsv0) and were never audited. For help migrating older deployments, see [docs/migration-guide.md](docs/migration-guide.md).
 
 > **Legacy resources:** Historical AGIJobsv0 materials remain available in the archived [MontrealAI/AGIJobsv0](https://github.com/MontrealAI/AGIJobsv0) repository. This project carries forward maintained guides under `docs/`, while preserved v0 references now live in [`docs/legacy/`](docs/legacy/README.md).
 
@@ -118,7 +118,7 @@ For a step-by-step mainnet deployment using Truffle, see the [Deploying AGIJobs 
 
 ## Migrating from legacy
 
-The original v0 and v1 contracts are preserved under the `legacy` git tag for reference only and receive no support. New development should target the v2 modules in `contracts`. See [docs/migration-guide.md](docs/migration-guide.md) for help mapping legacy entry points to their v2 equivalents.
+The original v0 and v1 contracts remain available in the archived repository history (see the `legacy` tag in [MontrealAI/AGIJobsv0](https://github.com/MontrealAI/AGIJobsv0)) and receive no support. New development should target the v2 modules in `contracts`. See [docs/migration-guide.md](docs/migration-guide.md) for help mapping legacy entry points to their v2 equivalents.
 
 ## Quick Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "agijobsv0",
-  "version": "1.0.0",
+  "name": "agijobsv2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agijobsv0",
-      "version": "1.0.0",
+      "name": "agijobsv2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@prb/math": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "agijobsv0",
-  "version": "1.0.0",
+  "name": "agijobsv2",
+  "version": "2.0.0",
   "description": "[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![CI](https://github.com/MontrealAI/AGIJobsv2/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobsv2/actions/workflows/ci.yml)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- clarify in the README that the maintained v2 contracts live at the repository root and that legacy code remains in the archived AGIJobsv0 repo
- rename the npm package to `agijobsv2` and bump its version metadata to 2.0.0 in both package.json and the lockfile

## Testing
- npm run compile
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d20dc422d08333b4e89afca93e7311