### PR TITLE
Add governance orchestrator and expose config helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ Use the `examples/ethers-quickstart.js` script to interact with the deployed con
 
 The [API reference](docs/api-reference.md) describes every public contract function and includes TypeScript and Python snippets. For an event‑driven workflow check the minimal [agent gateway](examples/agent-gateway.js) that listens for `JobCreated` events and applies automatically.
 
+### Governance control center
+
+Run the orchestrator to synchronise every owner-controlled module with the committed configuration in one command:
+
+```bash
+npm run owner:plan -- --network <network>
+```
+
+The command performs a dry run by default, streaming the output of each module script listed in [`config/governance-control.json`](config/governance-control.json). To apply the updates, append `--execute` (or run `npm run owner:apply -- --network <network>`). Filter to a subset of modules using `--module FeePool --module StakeManager`, or skip a module with `--skip TaxPolicy`. The orchestrator validates the Hardhat installation, halts on the first error, and preserves the detailed audit trail already produced by the underlying scripts.
+
 ### Network timeouts
 
 Outbound HTTP requests from the gateway, example agents and validator UI respect the `FETCH_TIMEOUT_MS` environment variable (default `5000` milliseconds). Browser clients read the value from `NEXT_PUBLIC_FETCH_TIMEOUT_MS`.

--- a/config/governance-control.json
+++ b/config/governance-control.json
@@ -1,0 +1,34 @@
+{
+  "modules": [
+    {
+      "name": "JobRegistry",
+      "script": "scripts/updateJobRegistry.ts",
+      "args": [],
+      "description": "Synchronize JobRegistry treasury, tax policy, stakes, and acknowledgers from config/job-registry.json."
+    },
+    {
+      "name": "StakeManager",
+      "script": "scripts/updateStakeManager.ts",
+      "args": [],
+      "description": "Apply treasury, module wiring, staking, and penalty configuration from config/stake-manager.json."
+    },
+    {
+      "name": "FeePool",
+      "script": "scripts/updateFeePool.ts",
+      "args": [],
+      "description": "Update reward routing, burn percentage, treasury controls, and rewarder permissions via config/fee-pool.json."
+    },
+    {
+      "name": "PlatformIncentives",
+      "script": "scripts/updatePlatformIncentives.ts",
+      "args": [],
+      "description": "Ensure PlatformIncentives wiring matches config/platform-incentives.json."
+    },
+    {
+      "name": "TaxPolicy",
+      "script": "scripts/updateTaxPolicy.ts",
+      "args": [],
+      "description": "Publish the latest tax policy URI and acknowledgers from config/tax-policy.json."
+    }
+  ]
+}

--- a/config/index.d.ts
+++ b/config/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../scripts/config';

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../scripts/config');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "build:gateway": "tsc -p agent-gateway/tsconfig.json",
     "agent:gateway": "node examples/agentic/v2-agent-gateway.js",
     "agent:validator": "node examples/agentic/v2-validator.js",
+    "owner:plan": "npx ts-node scripts/governance/apply-config.ts",
+    "owner:apply": "npm run owner:plan -- --execute",
     "format": "prettier --write \"**/*.{js,ts,md}\"",
     "format:check": "prettier --check \"**/*.{js,ts,md}\"",
     "identity:register": "npx ts-node scripts/identity/manageEnsKeys.ts",

--- a/scripts/governance/apply-config.ts
+++ b/scripts/governance/apply-config.ts
@@ -1,0 +1,286 @@
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+interface ModuleConfig {
+  name: string;
+  script: string;
+  args?: string[];
+  description?: string;
+  optional?: boolean;
+}
+
+interface GovernanceControl {
+  modules: ModuleConfig[];
+}
+
+interface CliOptions {
+  configPath?: string;
+  network?: string;
+  execute: boolean;
+  modules?: string[];
+  skip?: string[];
+  list?: boolean;
+  help?: boolean;
+  quiet?: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--config': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--config requires a file path');
+        }
+        options.configPath = value;
+        i += 1;
+        break;
+      }
+      case '--network': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--network requires a value');
+        }
+        options.network = value;
+        i += 1;
+        break;
+      }
+      case '--module':
+      case '--only': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a module name`);
+        }
+        if (!options.modules) {
+          options.modules = [];
+        }
+        options.modules.push(value);
+        i += 1;
+        break;
+      }
+      case '--skip': {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error('--skip requires a module name');
+        }
+        if (!options.skip) {
+          options.skip = [];
+        }
+        options.skip.push(value);
+        i += 1;
+        break;
+      }
+      case '--execute': {
+        options.execute = true;
+        break;
+      }
+      case '--quiet': {
+        options.quiet = true;
+        break;
+      }
+      case '--list': {
+        options.list = true;
+        break;
+      }
+      case '--help':
+      case '-h': {
+        options.help = true;
+        break;
+      }
+      default: {
+        throw new Error(`Unknown argument: ${arg}`);
+      }
+    }
+  }
+  return options;
+}
+
+function normaliseModuleName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function loadGovernanceControl(configPath: string): GovernanceControl {
+  if (!fs.existsSync(configPath)) {
+    throw new Error(`Governance control config not found at ${configPath}`);
+  }
+  const raw = fs.readFileSync(configPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.modules)) {
+    throw new Error('governance-control config must contain a modules array');
+  }
+  return parsed as GovernanceControl;
+}
+
+function resolveHardhatBinary(repoRoot: string): string {
+  const binaryName = process.platform === 'win32' ? 'hardhat.cmd' : 'hardhat';
+  const candidate = path.join(repoRoot, 'node_modules', '.bin', binaryName);
+  if (!fs.existsSync(candidate)) {
+    throw new Error(
+      `Hardhat binary not found at ${candidate}. Run "npm install" before executing this script.`
+    );
+  }
+  return candidate;
+}
+
+function formatModule(module: ModuleConfig): string {
+  const details = [module.name];
+  if (module.description) {
+    details.push(`- ${module.description}`);
+  }
+  return details.join(' ');
+}
+
+async function main() {
+  try {
+    const argv = process.argv.slice(2);
+    const options = parseArgs(argv);
+
+    if (options.help) {
+      console.log(
+        `Usage: ts-node scripts/governance/apply-config.ts [options]\n\n` +
+          'Options:\n' +
+          '  --config <path>   Path to governance-control.json (default: config/governance-control.json)\n' +
+          '  --network <name>  Hardhat network name to forward to each module script\n' +
+          '  --module <name>   Only run the specified module (can be repeated)\n' +
+          '  --skip <name>     Skip the specified module (can be repeated)\n' +
+          '  --execute         Apply changes instead of performing a dry run\n' +
+          '  --quiet           Reduce log verbosity\n' +
+          '  --list            List modules and exit\n' +
+          '  -h, --help        Show this help message\n'
+      );
+      return;
+    }
+
+    const repoRoot = path.resolve(__dirname, '..', '..');
+    const defaultConfig = path.join(
+      repoRoot,
+      'config',
+      'governance-control.json'
+    );
+    const configPath = options.configPath
+      ? path.resolve(process.cwd(), options.configPath)
+      : defaultConfig;
+
+    const control = loadGovernanceControl(configPath);
+    const modules = control.modules || [];
+
+    if (modules.length === 0) {
+      console.log(
+        'No modules declared in governance-control config. Nothing to do.'
+      );
+      return;
+    }
+
+    const moduleFilter = options.modules
+      ? new Set(options.modules.map(normaliseModuleName))
+      : undefined;
+    const skipFilter = options.skip
+      ? new Set(options.skip.map(normaliseModuleName))
+      : new Set<string>();
+
+    const selectedModules = modules.filter((module) => {
+      const normalized = normaliseModuleName(module.name);
+      if (moduleFilter && !moduleFilter.has(normalized)) {
+        return false;
+      }
+      if (skipFilter.has(normalized)) {
+        return false;
+      }
+      return true;
+    });
+
+    if (options.list) {
+      console.log(`Loaded ${modules.length} module(s) from ${configPath}`);
+      modules.forEach((module) => {
+        console.log(`- ${formatModule(module)}`);
+      });
+      if (moduleFilter) {
+        console.log('\nFiltered selection:');
+        selectedModules.forEach((module) => {
+          console.log(`- ${module.name}`);
+        });
+      }
+      return;
+    }
+
+    if (selectedModules.length === 0) {
+      console.log('No modules matched the provided filters. Nothing to run.');
+      return;
+    }
+
+    const hardhatBin = resolveHardhatBinary(repoRoot);
+    const modeLabel = options.execute ? 'EXECUTE' : 'DRY-RUN';
+
+    if (!options.quiet) {
+      console.log(`Owner control orchestrator (${modeLabel})`);
+      console.log(`Config: ${configPath}`);
+      if (options.network) {
+        console.log(`Network: ${options.network}`);
+      }
+      console.log(`Selected modules (${selectedModules.length}):`);
+      selectedModules.forEach((module, index) => {
+        const prefix = `${index + 1}.`;
+        console.log(`  ${prefix} ${formatModule(module)}`);
+      });
+    }
+
+    for (const module of selectedModules) {
+      const scriptPath = path.resolve(repoRoot, module.script);
+      if (!fs.existsSync(scriptPath)) {
+        if (module.optional) {
+          if (!options.quiet) {
+            console.warn(
+              `Skipping optional module ${module.name} because script ${scriptPath} does not exist.`
+            );
+          }
+          continue;
+        }
+        throw new Error(
+          `Module ${module.name} references missing script ${scriptPath}. Update config/governance-control.json or restore the script.`
+        );
+      }
+
+      if (!options.quiet) {
+        console.log(`\n>>> Running ${module.name} (${module.script})`);
+      }
+
+      const args: string[] = ['run', scriptPath];
+      if (options.network) {
+        args.push('--network', options.network);
+      }
+      if (Array.isArray(module.args) && module.args.length > 0) {
+        args.push(...module.args);
+      }
+      if (options.execute) {
+        args.push('--execute');
+      }
+
+      const result = spawnSync(hardhatBin, args, {
+        cwd: repoRoot,
+        stdio: 'inherit',
+        env: { ...process.env },
+      });
+
+      if (result.error) {
+        throw result.error;
+      }
+      if (typeof result.status === 'number' && result.status !== 0) {
+        throw new Error(
+          `${module.name} update script exited with status ${result.status}. Aborting.`
+        );
+      }
+    }
+
+    if (!options.quiet) {
+      console.log('\nAll selected modules completed successfully.');
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}
+
+void main();


### PR DESCRIPTION
## Summary
- add a TypeScript orchestration script that runs the owner maintenance modules with a single command and supports filtering, dry-run, and execution modes
- document the new owner control workflow in the README and wire npm scripts for easy access to the orchestrator
- expose the existing configuration helpers under config/index.* and seed a governance-control.json manifest that enumerates the supported module scripts

## Testing
- npx ts-node scripts/governance/apply-config.ts --list
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d40d775e288333832aa913c3782d8a