### PR TITLE
Add ENS root alias support for identity verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AGIJob Manager is an experimental suite of Ethereum smart contracts and tooling 
 
 > **Legacy resources:** Historical AGIJobsv0 materials remain available in the archived [MontrealAI/AGIJobsv0](https://github.com/MontrealAI/AGIJobsv0) repository. This project carries forward maintained guides under `docs/`, while preserved v0 references now live in [`docs/legacy/`](docs/legacy/README.md).
 
-> **ENS identity required:** Before participating, each agent or validator must control an ENS subdomain. Agents use `<name>.agent.agi.eth` and validators use `<name>.club.agi.eth`. Follow the [ENS identity setup guide](docs/ens-identity-setup.md) to register and configure your name.
+> **ENS identity required:** Before participating, each agent or validator must control an ENS subdomain. Agents use `<name>.agent.agi.eth` (or `<name>.alpha.agent.agi.eth`) and validators use `<name>.club.agi.eth` (or `<name>.alpha.club.agi.eth`). Follow the [ENS identity setup guide](docs/ens-identity-setup.md) to register and configure your name.
 
 All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes and dispute deposits with the token address fixed at deployment. The canonical token is deployed externally; this repository ships [`contracts/test/AGIALPHAToken.sol`](contracts/test/AGIALPHAToken.sol) for local testing only. Token address and decimal configuration live in [`config/agialpha.json`](config/agialpha.json) and feed both Solidity and TypeScript consumers.
 
@@ -33,7 +33,7 @@ All modules now assume the 18‑decimal `$AGIALPHA` token for payments, stakes a
 
 ### Identity policy
 
-Agents and validators must own ENS subdomains under `agent.agi.eth` and `club.agi.eth`. All workflows perform on-chain verification and bypass mechanisms are reserved for emergency governance only. See [docs/ens-identity-policy.md](docs/ens-identity-policy.md) for details.
+Agents and validators must own ENS subdomains under `agent.agi.eth`/`alpha.agent.agi.eth` and `club.agi.eth`/`alpha.club.agi.eth`. All workflows perform on-chain verification and bypass mechanisms are reserved for emergency governance only. See [docs/ens-identity-policy.md](docs/ens-identity-policy.md) for details.
 
 > **Emergency allowlists:** The `IdentityRegistry` owner can directly whitelist addresses using `addAdditionalAgent` or `addAdditionalValidator`. These overrides bypass ENS proofs and should only be used to recover from deployment errors or other emergencies.
 
@@ -272,7 +272,7 @@ halt procedures, and monitoring, consult
 All participants must prove ownership of a subdomain in the AGI ENS
 namespace before interacting with the system:
 
-- **Agents** use `<name>.agent.agi.eth`.
+- **Agents** use `<name>.agent.agi.eth` (aliases under `alpha.agent.agi.eth` are also accepted).
 - **Validators** use `<name>.club.agi.eth`.
 
 To register:

--- a/config/ens.json
+++ b/config/ens.json
@@ -3,13 +3,29 @@
     "name": "agent.agi.eth",
     "node": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",
     "resolver": "0x0000000000000000000000000000000000000000",
-    "role": "agent"
+    "role": "agent",
+    "aliases": [
+      {
+        "name": "alpha.agent.agi.eth",
+        "label": "alpha",
+        "labelhash": "0x6dfc21ac0c8c2db036305d8bc6f887630d35e156f37d5a7e2275bc05bc004846",
+        "node": "0xc74b6c5e8a0d97ed1fe28755da7d06a84593b4de92f6582327bc40f41d6c2d5e"
+      }
+    ]
   },
   "club": {
     "name": "club.agi.eth",
     "node": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16",
     "resolver": "0x0000000000000000000000000000000000000000",
-    "role": "validator"
+    "role": "validator",
+    "aliases": [
+      {
+        "name": "alpha.club.agi.eth",
+        "label": "alpha",
+        "labelhash": "0x6dfc21ac0c8c2db036305d8bc6f887630d35e156f37d5a7e2275bc05bc004846",
+        "node": "0x6487f659ec6f3fbd424b18b685728450d2559e4d68768393f9c689b2b6e5405e"
+      }
+    ]
   },
   "business": {
     "name": "a.agi.eth",

--- a/config/ens.mainnet.json
+++ b/config/ens.mainnet.json
@@ -9,7 +9,15 @@
       "labelhash": "0x314c1dfbbccab41a44cf9fefc21e632eb8e01bc0346d4414114d4c3dd0e9fdf1",
       "node": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",
       "merkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "role": "agent"
+      "role": "agent",
+      "aliases": [
+        {
+          "name": "alpha.agent.agi.eth",
+          "label": "alpha",
+          "labelhash": "0x6dfc21ac0c8c2db036305d8bc6f887630d35e156f37d5a7e2275bc05bc004846",
+          "node": "0xc74b6c5e8a0d97ed1fe28755da7d06a84593b4de92f6582327bc40f41d6c2d5e"
+        }
+      ]
     },
     "club": {
       "label": "club",
@@ -17,7 +25,15 @@
       "labelhash": "0xe1e1884f7473923c2fed5da5f5489310ba525a82307b50b511b8963ee9b20113",
       "node": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16",
       "merkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "role": "validator"
+      "role": "validator",
+      "aliases": [
+        {
+          "name": "alpha.club.agi.eth",
+          "label": "alpha",
+          "labelhash": "0x6dfc21ac0c8c2db036305d8bc6f887630d35e156f37d5a7e2275bc05bc004846",
+          "node": "0x6487f659ec6f3fbd424b18b685728450d2559e4d68768393f9c689b2b6e5405e"
+        }
+      ]
     },
     "business": {
       "label": "a",

--- a/config/ens.sepolia.json
+++ b/config/ens.sepolia.json
@@ -9,7 +9,15 @@
       "labelhash": "0x314c1dfbbccab41a44cf9fefc21e632eb8e01bc0346d4414114d4c3dd0e9fdf1",
       "node": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",
       "merkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "role": "agent"
+      "role": "agent",
+      "aliases": [
+        {
+          "name": "alpha.agent.agi.eth",
+          "label": "alpha",
+          "labelhash": "0x6dfc21ac0c8c2db036305d8bc6f887630d35e156f37d5a7e2275bc05bc004846",
+          "node": "0xc74b6c5e8a0d97ed1fe28755da7d06a84593b4de92f6582327bc40f41d6c2d5e"
+        }
+      ]
     },
     "club": {
       "label": "club",
@@ -17,7 +25,15 @@
       "labelhash": "0xe1e1884f7473923c2fed5da5f5489310ba525a82307b50b511b8963ee9b20113",
       "node": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16",
       "merkleRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "role": "validator"
+      "role": "validator",
+      "aliases": [
+        {
+          "name": "alpha.club.agi.eth",
+          "label": "alpha",
+          "labelhash": "0x6dfc21ac0c8c2db036305d8bc6f887630d35e156f37d5a7e2275bc05bc004846",
+          "node": "0x6487f659ec6f3fbd424b18b685728450d2559e4d68768393f9c689b2b6e5405e"
+        }
+      ]
     },
     "business": {
       "label": "a",

--- a/contracts/interfaces/IIdentityRegistry.sol
+++ b/contracts/interfaces/IIdentityRegistry.sol
@@ -8,6 +8,11 @@ interface IIdentityRegistry {
         Human,
         AI
     }
+
+    struct RootAliasConfig {
+        bytes32 root;
+        bool enabled;
+    }
     function isAuthorizedAgent(
         address claimant,
         string calldata subdomain,
@@ -40,6 +45,14 @@ interface IIdentityRegistry {
     function setClubRootNode(bytes32 root) external;
     function setAgentMerkleRoot(bytes32 root) external;
     function setValidatorMerkleRoot(bytes32 root) external;
+    function setAgentRootAlias(bytes32 root, bool enabled) external;
+    function setClubRootAlias(bytes32 root, bool enabled) external;
+    function setAgentRootAliases(RootAliasConfig[] calldata updates) external;
+    function setClubRootAliases(RootAliasConfig[] calldata updates) external;
+    function applyAliasConfiguration(
+        RootAliasConfig[] calldata agentAliases,
+        RootAliasConfig[] calldata clubAliases
+    ) external;
 
     // manual allowlists
     function addAdditionalAgent(address agent) external;
@@ -53,6 +66,16 @@ interface IIdentityRegistry {
     function additionalAgents(address account) external view returns (bool);
     function additionalValidators(address account) external view returns (bool);
     function getAgentType(address agent) external view returns (AgentType);
+    function getAgentRootAliases() external view returns (bytes32[] memory);
+    function getClubRootAliases() external view returns (bytes32[] memory);
+    function agentRootAliasInfo(bytes32 root)
+        external
+        view
+        returns (bool exists, bool enabled);
+    function clubRootAliasInfo(bytes32 root)
+        external
+        view
+        returns (bool exists, bool enabled);
 
     // profile metadata
     function setAgentProfileURI(address agent, string calldata uri) external;

--- a/contracts/mocks/ReentrantIdentityRegistry.sol
+++ b/contracts/mocks/ReentrantIdentityRegistry.sol
@@ -101,6 +101,14 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
     function setClubRootNode(bytes32) external {}
     function setAgentMerkleRoot(bytes32) external {}
     function setValidatorMerkleRoot(bytes32) external {}
+    function setAgentRootAlias(bytes32, bool) external {}
+    function setClubRootAlias(bytes32, bool) external {}
+    function setAgentRootAliases(RootAliasConfig[] calldata) external {}
+    function setClubRootAliases(RootAliasConfig[] calldata) external {}
+    function applyAliasConfiguration(
+        RootAliasConfig[] calldata,
+        RootAliasConfig[] calldata
+    ) external {}
 
     // allowlists - no-ops
     function addAdditionalAgent(address) external {}
@@ -120,5 +128,29 @@ contract ReentrantIdentityRegistry is IIdentityRegistry {
 
     function getAgentType(address) external pure returns (AgentType) {
         return AgentType.Human;
+    }
+
+    function getAgentRootAliases() external pure returns (bytes32[] memory aliases) {
+        return new bytes32[](0);
+    }
+
+    function getClubRootAliases() external pure returns (bytes32[] memory aliases) {
+        return new bytes32[](0);
+    }
+
+    function agentRootAliasInfo(bytes32)
+        external
+        pure
+        returns (bool exists, bool enabled)
+    {
+        return (false, false);
+    }
+
+    function clubRootAliasInfo(bytes32)
+        external
+        pure
+        returns (bool exists, bool enabled)
+    {
+        return (false, false);
     }
 }

--- a/docs/ens-identity-policy.md
+++ b/docs/ens-identity-policy.md
@@ -4,8 +4,8 @@ All participation in AGIJobs requires on‑chain proof of ENS subdomain ownershi
 
 ## Requirements
 
-- **Agents** must own an ENS subdomain under `agent.agi.eth` and present it when applying for or submitting jobs.
-- **Validators** must own a subdomain under `club.agi.eth` for committing or revealing validation results.
+- **Agents** must own an ENS subdomain under `agent.agi.eth` (or the delegated alias root `alpha.agent.agi.eth`) and present it when applying for or submitting jobs.
+- **Validators** must own a subdomain under `club.agi.eth` (or `alpha.club.agi.eth`) for committing or revealing validation results.
 - Owner controlled allowlists and Merkle proofs exist only for emergency governance and migration. Regular participants are expected to use ENS.
 - Attestations may be recorded in `AttestationRegistry` to cache successful checks and reduce gas usage, but they do not bypass the ENS requirement.
 

--- a/docs/ens-identity-setup.md
+++ b/docs/ens-identity-setup.md
@@ -1,6 +1,6 @@
 # ENS Identity Setup
 
-Agents and validators must prove ownership of specific ENS subdomains before interacting with the AGIJobs platform. This guide walks through obtaining a name, configuring records, and optionally delegating access.
+Agents and validators must prove ownership of specific ENS subdomains before interacting with the AGIJobs platform. This guide walks through obtaining a name, configuring records, and optionally delegating access. Primary roots live under `agent.agi.eth` and `club.agi.eth`, and the system recognises delegated aliases under `alpha.agent.agi.eth` and `alpha.club.agi.eth` with identical verification rules.
 
 ## Agent gateway automation
 

--- a/scripts/config/index.d.ts
+++ b/scripts/config/index.d.ts
@@ -223,6 +223,15 @@ export interface EnsRootConfig {
   merkleRoot: string;
   role?: string;
   resolver?: string;
+  aliases?: EnsRootAliasConfig[];
+  [key: string]: unknown;
+}
+
+export interface EnsRootAliasConfig {
+  name: string;
+  label: string;
+  labelhash: string;
+  node: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- add configurable ENS root alias tracking in IdentityRegistry with canonical alpha nodes preconfigured for mainnet
- extend TypeScript config loaders, JSON configs, and documentation to normalise and surface alias ENS roots for agents and validators
- update identity-related tests to cover alias verification paths and ensure configureMainnet enables canonical aliases

## Testing
- NODE_OPTIONS='-r ts-node/register/transpile-only' npx hardhat test test/identity.test.ts
- npx hardhat test test/IdentityRegistrySetters.test.js test/IdentityVerification.test.js
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d42854de1083339f8141350f6c5417