### PR TITLE
Protect canonical ENS alias equivalence

### DIFF
--- a/contracts/IdentityRegistry.sol
+++ b/contracts/IdentityRegistry.sol
@@ -14,6 +14,7 @@ error EtherNotAccepted();
 error IncompatibleReputationEngine();
 error InvalidRootAlias();
 error CannotDisablePrimaryRoot();
+error CannotDisableCanonicalAlias();
 
 /// @title IdentityRegistry
 /// @notice Verifies ENS subdomain ownership and tracks manual allowlists
@@ -467,6 +468,9 @@ contract IdentityRegistry is Ownable2Step {
         if (root == agentRootNode && !enabled) {
             revert CannotDisablePrimaryRoot();
         }
+        if (root == MAINNET_ALPHA_AGENT_ROOT_NODE && !enabled) {
+            revert CannotDisableCanonicalAlias();
+        }
         AliasStatus storage status = agentRootAliasStatus[root];
         if (!status.exists) {
             agentRootAliasList.push(root);
@@ -484,6 +488,9 @@ contract IdentityRegistry is Ownable2Step {
         }
         if (root == clubRootNode && !enabled) {
             revert CannotDisablePrimaryRoot();
+        }
+        if (root == MAINNET_ALPHA_CLUB_ROOT_NODE && !enabled) {
+            revert CannotDisableCanonicalAlias();
         }
         AliasStatus storage status = clubRootAliasStatus[root];
         if (!status.exists) {

--- a/test/IdentityRegistrySetters.test.js
+++ b/test/IdentityRegistrySetters.test.js
@@ -210,6 +210,19 @@ describe('IdentityRegistry setters', function () {
       expect(enabled).to.equal(false);
     });
 
+    it('does not allow disabling the canonical alpha aliases', async () => {
+      const alphaAgent = await identity.MAINNET_ALPHA_AGENT_ROOT_NODE();
+      const alphaClub = await identity.MAINNET_ALPHA_CLUB_ROOT_NODE();
+
+      await expect(
+        identity.setAgentRootAlias(alphaAgent, false)
+      ).to.be.revertedWithCustomError(identity, 'CannotDisableCanonicalAlias');
+
+      await expect(
+        identity.setClubRootAlias(alphaClub, false)
+      ).to.be.revertedWithCustomError(identity, 'CannotDisableCanonicalAlias');
+    });
+
     it('allows batched alias updates with tracking', async () => {
       const clubAlias = ethers.id('club-alias');
       const startAgentAliases = await identity.getAgentRootAliases();

--- a/test/scripts/verify-ens-aliases.test.js
+++ b/test/scripts/verify-ens-aliases.test.js
@@ -129,14 +129,9 @@ describe('verifyEnsAliases script', () => {
       aliasLabel: 'Alpha',
     });
     const config = JSON.parse(require('fs').readFileSync(configPath, 'utf8'));
-    config.agent.aliases[0].labelhash = ethers.hexlify(
-      ethers.randomBytes(32)
-    );
+    config.agent.aliases[0].labelhash = ethers.hexlify(ethers.randomBytes(32));
     config.club.aliases[0].labelhash = config.agent.aliases[0].labelhash;
-    require('fs').writeFileSync(
-      configPath,
-      JSON.stringify(config, null, 2)
-    );
+    require('fs').writeFileSync(configPath, JSON.stringify(config, null, 2));
     try {
       expectThrow(
         () => verifyEnsAliases(configPath, identityPath),


### PR DESCRIPTION
## Summary
- prevent disabling the canonical alpha ENS aliases by introducing a dedicated guard in `IdentityRegistry`
- extend the IdentityRegistry setter suite to assert the alpha aliases always revert when toggled off
- tidy the ENS alias verification script test fixtures for formatting consistency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d48e3d58dc833384e791f72d8b9cfe