### PR TITLE
Enhance ENS configuration tooling and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,25 @@ For a detailed walkthrough see
 [docs/ens-identity-setup.md](docs/ens-identity-setup.md), including operator
 steps for issuing subdomains.
 
+Operators can synchronise the on-chain ENS configuration at any time with:
+
+```bash
+IDENTITY_REGISTRY=<registry>
+ENS_REGISTRY=<ens>
+NAME_WRAPPER=<wrapper>
+AGENT_ROOT_NODE=agent.agi.eth \
+CLUB_ROOT_NODE=club.agi.eth \
+ENABLE_AGENT_ALIASES=alpha.agent.agi.eth \
+ENABLE_CLUB_ALIASES=alpha.club.agi.eth \
+npx hardhat run scripts/configureEns.ts --network <network>
+```
+
+`AGENT_ROOT_NODE`/`CLUB_ROOT_NODE` accept either raw node hashes or ENS
+names; the script resolves them and automatically keeps the canonical
+`alpha.agent.agi.eth`/`alpha.club.agi.eth` aliases enabled. Additional
+aliases can be managed by setting comma-separated lists in
+`ENABLE_*_ALIASES` and `DISABLE_*_ALIASES`.
+
 ### Delegate addresses with AttestationRegistry
 
 `AttestationRegistry` lets ENS name owners pre-authorize other addresses for

--- a/scripts/configureEns.ts
+++ b/scripts/configureEns.ts
@@ -1,37 +1,197 @@
 import { ethers } from 'hardhat';
+import type { ContractTransactionResponse } from 'ethers';
+
+type AliasUpdate = { root: string; enabled: boolean };
+
+function requireAddress(value: string | undefined, label: string): string {
+  if (!value) {
+    throw new Error(`${label} env var required`);
+  }
+  try {
+    return ethers.getAddress(value);
+  } catch (err) {
+    throw new Error(`${label} must be a valid address`);
+  }
+}
+
+function parseNode(value: string | undefined, label: string): string {
+  if (!value) {
+    throw new Error(`${label} env var required`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${label} env var required`);
+  }
+  if (ethers.isHexString(trimmed, 32)) {
+    return ethers.hexlify(trimmed);
+  }
+  if (trimmed.includes('.')) {
+    return ethers.namehash(trimmed.toLowerCase());
+  }
+  throw new Error(
+    `${label} must be a 32-byte hex string or a fully-qualified ENS name`
+  );
+}
+
+function parseAliasList(envKey: string, enabled: boolean): AliasUpdate[] {
+  const raw = process.env[envKey];
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => ({
+      root: parseNode(entry, envKey),
+      enabled,
+    }));
+}
+
+function mergeAliasUpdates(
+  base: AliasUpdate[],
+  additions: AliasUpdate[]
+): AliasUpdate[] {
+  const merged = [...base];
+  for (const update of additions) {
+    const index = merged.findIndex(
+      (candidate) => candidate.root.toLowerCase() === update.root.toLowerCase()
+    );
+    if (index >= 0) {
+      merged[index] = update;
+    } else {
+      merged.push(update);
+    }
+  }
+  return merged;
+}
+
+async function sendIfNeeded(
+  description: string,
+  current: string,
+  desired: string,
+  sender: () => Promise<ContractTransactionResponse>
+) {
+  if (current.toLowerCase() === desired.toLowerCase()) {
+    console.log(`${description} already set to ${desired}`);
+    return;
+  }
+  const tx = await sender();
+  console.log(`${description} tx: ${tx.hash}`);
+  await tx.wait();
+}
+
+async function ensureCanonicalAlias(
+  label: string,
+  canonicalRoot: string,
+  infoFetcher: (root: string) => Promise<{ exists: boolean; enabled: boolean }>,
+  updates: AliasUpdate[]
+): Promise<AliasUpdate[]> {
+  const lowerCanonical = canonicalRoot.toLowerCase();
+  if (
+    updates.some(
+      (update) =>
+        update.root.toLowerCase() === lowerCanonical && update.enabled === false
+    )
+  ) {
+    throw new Error(
+      `${label} cannot be disabled. Remove it from the ${label} updates.`
+    );
+  }
+
+  if (
+    updates.some(
+      (update) =>
+        update.root.toLowerCase() === lowerCanonical && update.enabled === true
+    )
+  ) {
+    return updates;
+  }
+
+  const info = await infoFetcher(canonicalRoot);
+  const exists = (info as any).exists ?? (info as any)[0];
+  const enabled = (info as any).enabled ?? (info as any)[1];
+  if (!exists || !enabled) {
+    console.log(`Ensuring canonical ${label} alias is enabled`);
+    return [...updates, { root: canonicalRoot, enabled: true }];
+  }
+  return updates;
+}
 
 async function main() {
-  const registryAddr = process.env.IDENTITY_REGISTRY;
-  const ensAddr = process.env.ENS_REGISTRY;
-  const wrapperAddr = process.env.NAME_WRAPPER;
-  const agentRoot = process.env.AGENT_ROOT_NODE;
-  const clubRoot = process.env.CLUB_ROOT_NODE;
-  if (!registryAddr) throw new Error('IDENTITY_REGISTRY env var required');
-  if (!ensAddr) throw new Error('ENS_REGISTRY env var required');
-  if (!wrapperAddr) throw new Error('NAME_WRAPPER env var required');
-  if (!agentRoot) throw new Error('AGENT_ROOT_NODE env var required');
-  if (!clubRoot) throw new Error('CLUB_ROOT_NODE env var required');
+  const registryAddr = requireAddress(
+    process.env.IDENTITY_REGISTRY,
+    'IDENTITY_REGISTRY'
+  );
+  const ensAddr = requireAddress(process.env.ENS_REGISTRY, 'ENS_REGISTRY');
+  const wrapperAddr = requireAddress(process.env.NAME_WRAPPER, 'NAME_WRAPPER');
+  const agentRoot = parseNode(process.env.AGENT_ROOT_NODE, 'AGENT_ROOT_NODE');
+  const clubRoot = parseNode(process.env.CLUB_ROOT_NODE, 'CLUB_ROOT_NODE');
 
   const identity = await ethers.getContractAt(
     'contracts/IdentityRegistry.sol:IdentityRegistry',
     registryAddr
   );
 
-  let tx = await identity.setENS(ensAddr);
-  console.log(`setENS tx: ${tx.hash}`);
-  await tx.wait();
+  await sendIfNeeded('setENS', await identity.ens(), ensAddr, () =>
+    identity.setENS(ensAddr)
+  );
 
-  tx = await identity.setNameWrapper(wrapperAddr);
-  console.log(`setNameWrapper tx: ${tx.hash}`);
-  await tx.wait();
+  await sendIfNeeded(
+    'setNameWrapper',
+    await identity.nameWrapper(),
+    wrapperAddr,
+    () => identity.setNameWrapper(wrapperAddr)
+  );
 
-  tx = await identity.setAgentRootNode(agentRoot);
-  console.log(`setAgentRootNode tx: ${tx.hash}`);
-  await tx.wait();
+  await sendIfNeeded(
+    'setAgentRootNode',
+    await identity.agentRootNode(),
+    agentRoot,
+    () => identity.setAgentRootNode(agentRoot)
+  );
 
-  tx = await identity.setClubRootNode(clubRoot);
-  console.log(`setClubRootNode tx: ${tx.hash}`);
-  await tx.wait();
+  await sendIfNeeded(
+    'setClubRootNode',
+    await identity.clubRootNode(),
+    clubRoot,
+    () => identity.setClubRootNode(clubRoot)
+  );
+
+  let agentAliasUpdates = mergeAliasUpdates(
+    parseAliasList('ENABLE_AGENT_ALIASES', true),
+    parseAliasList('DISABLE_AGENT_ALIASES', false)
+  );
+  let clubAliasUpdates = mergeAliasUpdates(
+    parseAliasList('ENABLE_CLUB_ALIASES', true),
+    parseAliasList('DISABLE_CLUB_ALIASES', false)
+  );
+
+  const canonicalAgentRoot = await identity.MAINNET_ALPHA_AGENT_ROOT_NODE();
+  const canonicalClubRoot = await identity.MAINNET_ALPHA_CLUB_ROOT_NODE();
+
+  agentAliasUpdates = await ensureCanonicalAlias(
+    'alpha.agent.agi.eth',
+    canonicalAgentRoot,
+    async (root) => identity.agentRootAliasInfo(root),
+    agentAliasUpdates
+  );
+
+  clubAliasUpdates = await ensureCanonicalAlias(
+    'alpha.club.agi.eth',
+    canonicalClubRoot,
+    async (root) => identity.clubRootAliasInfo(root),
+    clubAliasUpdates
+  );
+
+  if (agentAliasUpdates.length || clubAliasUpdates.length) {
+    const tx = await identity.applyAliasConfiguration(
+      agentAliasUpdates,
+      clubAliasUpdates
+    );
+    console.log(`applyAliasConfiguration tx: ${tx.hash}`);
+    await tx.wait();
+  } else {
+    console.log('No alias updates requested');
+  }
 
   console.log('IdentityRegistry ENS configuration complete');
 }


### PR DESCRIPTION
## Summary
- expand `configureEns.ts` so operators can safely resync ENS/NameWrapper roots, apply alias updates from env vars, and auto-enforce the canonical alpha aliases
- allow ENS names or raw hashes in configuration, skip redundant transactions, and guard against disabling the canonical aliases
- document the updated workflow in the README with an example command and env variables for managing alias roots

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d49ff1bc208333b334b9939ced98b0