### PR TITLE
Add governance parameter helper and non-technical deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The script performs a dry run by default, reporting any address, ownership or pa
 
 For a step-by-step mainnet deployment using Truffle, see the [Deploying AGIJobs v2 to Ethereum Mainnet (CLI Guide)](docs/deploying-agijobs-v2-truffle-cli.md).
 
+- **New:** Non-technical operators can follow the streamlined [Non-Technical Production Deployment on Ethereum Mainnet](docs/deployment/non-technical-truffle-mainnet.md) playbook. It consolidates every command, checklist, and verification step (including the governance tuning helper) so a business owner can launch without writing code.
+
 - [docs/deployment-production-guide.md](docs/deployment-production-guide.md) – step-by-step walkthrough for deploying AGI Jobs v2 using only a web browser and Etherscan.
 - [docs/deployment-guide-production.md](docs/deployment-guide-production.md) – production deployment checklist.
 - [docs/agi-jobs-v2-production-deployment-guide.md](docs/agi-jobs-v2-production-deployment-guide.md) – non‑technical guide highlighting best practices such as true token burning and owner updatability.
@@ -136,6 +138,14 @@ npm run owner:plan -- --network <network>
 ```
 
 The command performs a dry run by default, streaming the output of each module script listed in [`config/governance-control.json`](config/governance-control.json). To apply the updates, append `--execute` (or run `npm run owner:apply -- --network <network>`). Filter to a subset of modules using `--module FeePool --module StakeManager`, or skip a module with `--skip TaxPolicy`. The orchestrator validates the Hardhat installation, halts on the first error, and preserves the detailed audit trail already produced by the underlying scripts.
+
+Need to change platform economics, treasury addresses, or tax policy text quickly? Populate `config/governance-update.json` (copy from [`config/governance-update.example.json`](config/governance-update.example.json)) and run:
+
+```bash
+npx hardhat run --network <network> scripts/governance/update-economics.ts --config config/governance-update.json
+```
+
+Append `--execute` to broadcast transactions once the dry-run summary looks correct. The helper prints current vs. desired values, method names, and transaction hashes for audit-ready change control.
 
 ### Network timeouts
 
@@ -204,14 +214,14 @@ Record each address during deployment. The defaults below assume the 18‑decima
 | Module                                                                     | Owner‑only setters                                                                                                                                             |
 | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`AGIALPHAToken`](contracts/test/AGIALPHAToken.sol) _(local testing only)_ | `mint`, `burn`                                                                                                                                                 |
-| [`StakeManager`](contracts/StakeManager.sol)                            | `setMinStake`, `setSlashingPercentages`, `setTreasury`, `setMaxStakePerAddress`                                                                                |
-| [`JobRegistry`](contracts/JobRegistry.sol)                              | `setModules`, `setFeePool`, `setTaxPolicy`, `setAgentRootNode`, `setAgentMerkleRoot`,<br>`setTreasury`, `setIdentityRegistry`                                  |
-| [`ValidationModule`](contracts/ValidationModule.sol)                    | `setJobRegistry`, `setCommitWindow`, `setRevealWindow`, `setValidatorBounds`, `setApprovalThreshold`, `setIdentityRegistry`                                    |
-| [`IdentityRegistry`](contracts/IdentityRegistry.sol)                    | `setENS`, `setNameWrapper`, `setReputationEngine`, `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot`, `setValidatorMerkleRoot`, `setAgentProfileURI` |
-| [`DisputeModule`](contracts/modules/DisputeModule.sol)                  | `setDisputeFee`, `setTaxPolicy`, `setFeePool`                                                                                                                  |
-| [`ReputationEngine`](contracts/ReputationEngine.sol)                    | `setCaller`, `setWeights`, `blacklist`, `unblacklist`                                                                                                          |
-| [`CertificateNFT`](contracts/CertificateNFT.sol)                        | `setJobRegistry`, `setStakeManager`, `setBaseURI` _(one-time IPFS prefix)_                                                                                     |
-| [`FeePool`](contracts/FeePool.sol)                                      | `setStakeManager`, `setRewardRole`, `setBurnPct`, `setTreasury`                                                                                                |
+| [`StakeManager`](contracts/StakeManager.sol)                               | `setMinStake`, `setSlashingPercentages`, `setTreasury`, `setMaxStakePerAddress`                                                                                |
+| [`JobRegistry`](contracts/JobRegistry.sol)                                 | `setModules`, `setFeePool`, `setTaxPolicy`, `setAgentRootNode`, `setAgentMerkleRoot`,<br>`setTreasury`, `setIdentityRegistry`                                  |
+| [`ValidationModule`](contracts/ValidationModule.sol)                       | `setJobRegistry`, `setCommitWindow`, `setRevealWindow`, `setValidatorBounds`, `setApprovalThreshold`, `setIdentityRegistry`                                    |
+| [`IdentityRegistry`](contracts/IdentityRegistry.sol)                       | `setENS`, `setNameWrapper`, `setReputationEngine`, `setAgentRootNode`, `setClubRootNode`, `setAgentMerkleRoot`, `setValidatorMerkleRoot`, `setAgentProfileURI` |
+| [`DisputeModule`](contracts/modules/DisputeModule.sol)                     | `setDisputeFee`, `setTaxPolicy`, `setFeePool`                                                                                                                  |
+| [`ReputationEngine`](contracts/ReputationEngine.sol)                       | `setCaller`, `setWeights`, `blacklist`, `unblacklist`                                                                                                          |
+| [`CertificateNFT`](contracts/CertificateNFT.sol)                           | `setJobRegistry`, `setStakeManager`, `setBaseURI` _(one-time IPFS prefix)_                                                                                     |
+| [`FeePool`](contracts/FeePool.sol)                                         | `setStakeManager`, `setRewardRole`, `setBurnPct`, `setTreasury`                                                                                                |
 
 ### Etherscan steps
 

--- a/config/governance-update.example.json
+++ b/config/governance-update.example.json
@@ -1,0 +1,62 @@
+{
+  "jobRegistry": {
+    "address": "0x0000000000000000000000000000000000000000",
+    "feePct": 5,
+    "validatorRewardPct": 15,
+    "treasury": "0x0000000000000000000000000000000000000000",
+    "jobStakeTokens": "10",
+    "minAgentStakeTokens": "100",
+    "maxJobRewardTokens": "10000",
+    "maxJobDurationSeconds": 604800,
+    "maxActiveJobsPerAgent": 3,
+    "expirationGracePeriodSeconds": 86400,
+    "taxPolicy": "0x0000000000000000000000000000000000000000",
+    "feePool": "0x0000000000000000000000000000000000000000"
+  },
+  "stakeManager": {
+    "address": "0x0000000000000000000000000000000000000000",
+    "minStakeTokens": "100",
+    "employerSlashPct": 50,
+    "treasurySlashPct": 25,
+    "treasury": "0x0000000000000000000000000000000000000000",
+    "treasuryAllowlist": [
+      {
+        "address": "0x0000000000000000000000000000000000000000",
+        "allowed": true
+      }
+    ],
+    "feePct": 5,
+    "burnPct": 5,
+    "validatorRewardPct": 15,
+    "unbondingPeriodSeconds": 604800,
+    "maxStakePerAddressTokens": "10000",
+    "stakeRecommendations": {
+      "minTokens": "100",
+      "maxTokens": "5000"
+    }
+  },
+  "feePool": {
+    "address": "0x0000000000000000000000000000000000000000",
+    "burnPct": 5,
+    "treasury": "0x0000000000000000000000000000000000000000",
+    "treasuryAllowlist": [
+      {
+        "address": "0x0000000000000000000000000000000000000000",
+        "allowed": true
+      }
+    ]
+  },
+  "taxPolicy": {
+    "address": "0x0000000000000000000000000000000000000000",
+    "policy": {
+      "uri": "ipfs://your-production-tax-policy",
+      "acknowledgement": "Employers, agents, and validators accept all tax responsibility."
+    },
+    "acknowledgers": [
+      {
+        "address": "0x0000000000000000000000000000000000000000",
+        "allowed": true
+      }
+    ]
+  }
+}

--- a/docs/deployment/non-technical-truffle-mainnet.md
+++ b/docs/deployment/non-technical-truffle-mainnet.md
@@ -1,0 +1,227 @@
+# Non-Technical Production Deployment on Ethereum Mainnet (Truffle CLI)
+
+This guide walks a non-technical operator through deploying the complete AGIJobs v2 stack to Ethereum mainnet using only the commands provided in this repository. No Solidity knowledge is required—every step is scripted and validated so you can focus on configuration and record keeping.
+
+- **Audience:** Business operators, operations managers, programme coordinators.
+- **Goal:** Deploy all AGIJobs v2 contracts, verify them, wire modules, and tune governance parameters using Truffle.
+- **Estimated time:** 45–60 minutes including verification and record keeping.
+
+> ⚠️ **High-stakes reminder:** Mainnet deployments are irreversible. Triple-check addresses, configuration files, and environment variables before sending any transaction.
+
+## 0. Prerequisites Checklist
+
+| Requirement               | Notes                                                                    |
+| ------------------------- | ------------------------------------------------------------------------ |
+| Node.js 20.x + npm 10+    | `nvm use` (repository ships `.nvmrc`).                                   |
+| Git                       | Clone or download the repository.                                        |
+| Ethereum mainnet RPC URL  | Infura, Alchemy, QuickNode, etc.                                         |
+| Deploy key (private key)  | The account that will broadcast migrations. Fund it with sufficient ETH. |
+| Governance address        | A multisig or timelock that will own the system post-deployment.         |
+| `$AGIALPHA` token address | Fixed at `config/agialpha.json` (already committed).                     |
+| Etherscan API key         | Enables automated verification.                                          |
+| ENS details               | Agent/validator roots in `deployment-config/mainnet.json`.               |
+
+**Documents to print / save:**
+
+- `deployment-config/mainnet.json`
+- `config/agialpha.json`
+- `config/governance-update.example.json`
+- Blank log sheet for recording contract addresses and transaction hashes.
+
+## 1. Environment Setup
+
+```bash
+# 1. Clone repository and enter directory
+git clone https://github.com/MontrealAI/AGIJobsv2.git
+cd AGIJobsv2
+
+# 2. Install Node.js version declared in .nvmrc
+nvm use
+
+# 3. Install dependencies
+npm install
+```
+
+Copy `.env.example` to `.env` and fill the values:
+
+```bash
+cp .env.example .env
+```
+
+Update `.env` with production values:
+
+```env
+MAINNET_RPC_URL=https://mainnet.infura.io/v3/<project>
+MAINNET_PRIVATE_KEY=0x<private-key-without-spaces>
+GOVERNANCE_ADDRESS=0xYourMultisig
+ETHERSCAN_API_KEY=<etherscan-api-key>
+```
+
+> ✅ **Safety tip:** use a dedicated deployer key with limited funds; move contract ownership to the governance multisig immediately after deployment.
+
+## 2. Review Canonical Token Configuration
+
+The `$AGIALPHA` metadata lives in `config/agialpha.json`. Do **not** edit unless the token contract changes. To validate configuration and regenerate Solidity constants run:
+
+```bash
+npm run compile
+```
+
+The command halts if token metadata is inconsistent and regenerates `contracts/Constants.sol` automatically.
+
+## 3. Fill Mainnet Deployment Configuration
+
+Edit `deployment-config/mainnet.json` with production parameters:
+
+- `governance.initial` — temporary owner during deployment (usually the deployer address).
+- `governance.final` — final governance multisig or timelock.
+- `stakeManager.minStakeTokens`, `employerSlashPct`, `treasurySlashPct`, `treasury`.
+- `feePool.burnPct`, `feePool.treasury`.
+- `jobRegistry.feePct`, `jobRegistry.jobStakeTokens`, `jobRegistry.treasury`.
+- `identity` section — set ENS registry (`0x0000…0C2E` on mainnet), NameWrapper, and namehashes. Use the helper:
+
+```bash
+npm run namehash:mainnet
+```
+
+This script rewrites the `hash` fields from human-readable names so migrations stay deterministic. Commit the file if you are preparing a PR.
+
+## 4. Dry-Run Safety Checks (Optional but Recommended)
+
+Before mainnet, perform a full rehearsal on Sepolia with identical settings:
+
+```bash
+# Populate deployment-config/sepolia.json with equivalent values
+npm run namehash:sepolia
+npm run migrate:sepolia
+```
+
+Use this rehearsal to record expected gas usage and ensure the deployer key is funded adequately.
+
+## 5. Execute Mainnet Deployment (Truffle)
+
+1. Confirm `.env` values one last time.
+2. Ensure `config/governance-update.json` exists. Start from the example:
+
+   ```bash
+   cp config/governance-update.example.json config/governance-update.json
+   # Edit with real contract addresses after deployment.
+   ```
+
+3. Deploy and wire the system:
+
+   ```bash
+   npm run migrate:mainnet
+   ```
+
+   This composite command performs:
+
+   - `npm run compile:mainnet` — regenerates constants and compiles with mainnet network selected.
+   - `npx truffle migrate --network mainnet --reset` — executes `migrations/1_initial_migration.js` through `4_governance_handover.js`.
+   - `npm run wire:verify` — sanity-checks module wiring against configuration files.
+
+4. During migration, copy every address printed in the console onto your log sheet. The deployer emits a summary block listing `StakeManager`, `JobRegistry`, `ValidationModule`, `ReputationEngine`, `DisputeModule`, `CertificateNFT`, `PlatformRegistry`, `JobRouter`, `PlatformIncentives`, `FeePool`, `TaxPolicy`, `IdentityRegistry`, and `SystemPause`.
+
+## 6. Verify Contracts on Etherscan
+
+The migration command triggers verification automatically when `ETHERSCAN_API_KEY` is set. To rerun verification manually (if rate limited):
+
+```bash
+npx truffle run verify Deployer StakeManager JobRegistry ValidationModule \
+  ReputationEngine DisputeModule CertificateNFT PlatformRegistry JobRouter \
+  PlatformIncentives FeePool IdentityRegistry SystemPause TaxPolicy \
+  --network mainnet
+```
+
+Record the verification URLs alongside each address.
+
+## 7. Post-Deployment Validation
+
+Run automated verifiers against mainnet state:
+
+```bash
+# Check $AGIALPHA metadata
+npm run verify:agialpha -- --rpc "$MAINNET_RPC_URL"
+
+# Confirm ENS aliases and namehash wiring
+npm run verify:ens
+
+# Re-run wiring assertion against live addresses
+TRUFFLE_NETWORK=mainnet MAINNET_RPC_URL=$MAINNET_RPC_URL \
+  MAINNET_PRIVATE_KEY=$MAINNET_PRIVATE_KEY npm run wire:verify
+```
+
+## 8. Tune Economics and Governance Parameters
+
+The repository now ships a consolidated governance helper at `scripts/governance/update-economics.ts`. Populate `config/governance-update.json` with the newly deployed addresses and desired parameters (percentages expressed as whole numbers, token amounts in 18‑decimal `$AGIALPHA` units).
+
+Example snippet:
+
+```json
+{
+  "jobRegistry": {
+    "address": "0xJobRegistry...",
+    "feePct": 5,
+    "validatorRewardPct": 15,
+    "jobStakeTokens": "25",
+    "minAgentStakeTokens": "250",
+    "treasury": "0xTreasury...",
+    "taxPolicy": "0xTaxPolicy...",
+    "feePool": "0xFeePool..."
+  },
+  "stakeManager": {
+    "address": "0xStakeManager...",
+    "minStakeTokens": "250",
+    "employerSlashPct": 50,
+    "treasurySlashPct": 10,
+    "treasury": "0xTreasury..."
+  }
+}
+```
+
+Dry-run the updates:
+
+```bash
+npx hardhat run --network mainnet scripts/governance/update-economics.ts --config config/governance-update.json
+```
+
+When the summary looks correct, append `--execute` to submit transactions:
+
+```bash
+npx hardhat run --network mainnet scripts/governance/update-economics.ts --config config/governance-update.json --execute
+```
+
+Each action prints the current value, desired value, method name, and transaction hash for audit trails.
+
+## 9. Transfer Ownership to Governance
+
+Hand off control to the governance multisig or timelock once parameters are tuned. The repository exposes batch helpers:
+
+```bash
+# Dry-run ownership transfer plan (defaults to config/governance-control.json)
+npm run owner:plan -- --network mainnet
+
+# Apply transfers once reviewed
+npm run owner:apply -- --network mainnet --execute
+```
+
+Alternatively, call `setGovernance` / `transferOwnership` from each contract via Etherscan using the addresses recorded earlier.
+
+## 10. Final Safety Checks
+
+- Execute `npm run verify:wiring` the next business day to confirm no drift.
+- Store the completed log sheet, `config/governance-update.json`, and deployment console output in your internal document vault.
+- Share the `deployment-addresses.json` entry with integrators and UI teams.
+- Schedule continuous monitoring following `docs/monitoring.md`.
+
+## Troubleshooting Quick Reference
+
+| Issue                                              | Resolution                                                                                                                                                         |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Governance update config not found`               | Copy `config/governance-update.example.json` to `config/governance-update.json`.                                                                                   |
+| Truffle migration reverts                          | Re-run with `DEBUG=agijobs npm run migrate:mainnet` to capture verbose logs; most failures stem from misconfigured ENS namehashes or missing `$AGIALPHA` balances. |
+| Verification fails                                 | Wait 2–3 minutes and rerun `npx truffle run verify ...`. Ensure `ETHERSCAN_API_KEY` is correct.                                                                    |
+| `No signer available` when running Hardhat scripts | Check `MAINNET_PRIVATE_KEY` in `.env` and confirm Hardhat network configuration matches.                                                                           |
+| Parameter transaction reverts                      | Verify governance ownership has not yet transferred; the deployer must still be the owner or you must switch to the governance multisig.                           |
+
+With these steps, a non-technical operator can confidently deploy AGIJobs v2, verify the contracts, and adjust all critical parameters from first principles using auditable scripts.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "agent:validator": "node examples/agentic/v2-validator.js",
     "owner:plan": "npx ts-node scripts/governance/apply-config.ts",
     "owner:apply": "npm run owner:plan -- --execute",
+    "owner:update": "npx hardhat run scripts/governance/update-economics.ts",
     "format": "prettier --write \"**/*.{js,ts,md}\"",
     "format:check": "prettier --check \"**/*.{js,ts,md}\"",
     "identity:register": "npx ts-node scripts/identity/manageEnsKeys.ts",

--- a/scripts/governance/update-economics.ts
+++ b/scripts/governance/update-economics.ts
@@ -1,0 +1,1007 @@
+import fs from 'fs';
+import path from 'path';
+import { ethers, artifacts, network } from 'hardhat';
+import type { Contract, Signer } from 'ethers';
+
+type PercentInput = number | string;
+type TokenAmountInput = number | string;
+type IntegerInput = number | string;
+
+interface TreasuryAllowlistUpdate {
+  address: string;
+  allowed: boolean;
+}
+
+interface JobRegistryConfig {
+  address: string;
+  feePct?: PercentInput;
+  validatorRewardPct?: PercentInput;
+  treasury?: string;
+  jobStakeTokens?: TokenAmountInput;
+  minAgentStakeTokens?: TokenAmountInput;
+  maxJobRewardTokens?: TokenAmountInput;
+  maxJobDurationSeconds?: IntegerInput;
+  maxActiveJobsPerAgent?: IntegerInput;
+  expirationGracePeriodSeconds?: IntegerInput;
+  taxPolicy?: string;
+  feePool?: string;
+}
+
+interface StakeManagerConfig {
+  address: string;
+  minStakeTokens?: TokenAmountInput;
+  employerSlashPct?: PercentInput;
+  treasurySlashPct?: PercentInput;
+  treasury?: string;
+  treasuryAllowlist?: TreasuryAllowlistUpdate[];
+  feePct?: PercentInput;
+  burnPct?: PercentInput;
+  validatorRewardPct?: PercentInput;
+  unbondingPeriodSeconds?: IntegerInput;
+  maxStakePerAddressTokens?: TokenAmountInput;
+  stakeRecommendations?: {
+    minTokens: TokenAmountInput;
+    maxTokens?: TokenAmountInput;
+  };
+}
+
+interface FeePoolConfig {
+  address: string;
+  burnPct?: PercentInput;
+  treasury?: string;
+  treasuryAllowlist?: TreasuryAllowlistUpdate[];
+}
+
+interface TaxPolicyConfig {
+  address: string;
+  policyURI?: string;
+  acknowledgement?: string;
+  policy?: {
+    uri: string;
+    acknowledgement: string;
+  };
+  acknowledgers?: TreasuryAllowlistUpdate[];
+}
+
+interface GovernanceUpdateConfig {
+  jobRegistry?: JobRegistryConfig;
+  stakeManager?: StakeManagerConfig;
+  feePool?: FeePoolConfig;
+  taxPolicy?: TaxPolicyConfig;
+}
+
+interface CliOptions {
+  configPath?: string;
+  execute: boolean;
+  quiet: boolean;
+}
+
+interface PlannedAction {
+  contract: Contract;
+  method: string;
+  args: unknown[];
+  description: string;
+  current?: string;
+  desired?: string;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false, quiet: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--config') {
+      const value = argv[i + 1];
+      if (!value) throw new Error('--config requires a file path');
+      options.configPath = value;
+      i += 1;
+    } else if (arg === '--execute') {
+      options.execute = true;
+    } else if (arg === '--quiet') {
+      options.quiet = true;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(
+        `Usage: npx hardhat run --network <network> ${path
+          .relative(process.cwd(), __filename)
+          .replace('\\', '/')} [options]\n\n` +
+          'Options:\n' +
+          '  --config <path>   Path to governance update JSON file\n' +
+          '  --execute         Apply the planned changes\n' +
+          '  --quiet           Only print warnings and summary\n' +
+          '  -h, --help        Show this help message\n'
+      );
+      process.exit(0);
+    }
+  }
+  return options;
+}
+
+function loadConfig(configPath?: string): GovernanceUpdateConfig {
+  const resolved = configPath
+    ? path.resolve(process.cwd(), configPath)
+    : path.resolve(__dirname, '..', '..', 'config', 'governance-update.json');
+  if (!fs.existsSync(resolved)) {
+    throw new Error(
+      `Governance update config not found at ${resolved}. Create one from config/governance-update.example.json`
+    );
+  }
+  const raw = fs.readFileSync(resolved, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Governance update config must be a JSON object');
+  }
+  return parsed as GovernanceUpdateConfig;
+}
+
+function ensureAddress(value: string | undefined, label: string): string {
+  if (!value) throw new Error(`${label} is required`);
+  try {
+    return ethers.getAddress(value);
+  } catch (error) {
+    throw new Error(
+      `${label} must be a valid address: ${(error as Error).message}`
+    );
+  }
+}
+
+function normaliseOptionalAddress(
+  value: string | undefined
+): string | undefined {
+  if (!value) return undefined;
+  return ethers.getAddress(value);
+}
+
+function formatAddress(value: string): string {
+  return ethers.getAddress(value);
+}
+
+function parsePercent(
+  value: PercentInput | undefined,
+  label: string
+): bigint | undefined {
+  if (value === undefined || value === null) return undefined;
+  const asString = typeof value === 'string' ? value.trim() : value.toString();
+  if (!asString) return undefined;
+  const parsed = Number(asString);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+  if (parsed < 0 || parsed > 100) {
+    throw new Error(`${label} must be between 0 and 100`);
+  }
+  return BigInt(Math.round(parsed));
+}
+
+function parseInteger(
+  value: IntegerInput | undefined,
+  label: string
+): bigint | undefined {
+  if (value === undefined || value === null) return undefined;
+  const asString = typeof value === 'string' ? value.trim() : value.toString();
+  if (!/^\d+$/.test(asString)) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return BigInt(asString);
+}
+
+function parseTokenAmount(
+  value: TokenAmountInput | undefined,
+  label: string
+): bigint | undefined {
+  if (value === undefined || value === null) return undefined;
+  const asString = typeof value === 'string' ? value.trim() : value.toString();
+  if (!asString) return undefined;
+  try {
+    return ethers.parseUnits(asString, 18);
+  } catch (error) {
+    throw new Error(
+      `${label} must be a valid decimal token amount: ${
+        (error as Error).message
+      }`
+    );
+  }
+}
+
+function formatPercent(value: bigint | number): string {
+  const asBigInt = typeof value === 'number' ? BigInt(value) : value;
+  return `${asBigInt.toString()}%`;
+}
+
+function formatTokenAmount(value: bigint): string {
+  return `${ethers.formatUnits(value, 18)} AGIALPHA`;
+}
+
+function formatSeconds(value: bigint): string {
+  return `${value.toString()} seconds`;
+}
+
+function sameAddress(a?: string, b?: string): boolean {
+  if (!a || !b) return false;
+  return ethers.getAddress(a) === ethers.getAddress(b);
+}
+
+async function connectContract(
+  name: string,
+  address: string,
+  signer: Signer
+): Promise<Contract> {
+  const artifact = await artifacts.readArtifact(name);
+  return new ethers.Contract(address, artifact.abi, signer);
+}
+
+async function planJobRegistryActions(
+  signer: Signer,
+  config: JobRegistryConfig,
+  options: CliOptions
+): Promise<PlannedAction[]> {
+  const actions: PlannedAction[] = [];
+  const jobRegistry = await connectContract(
+    'JobRegistry',
+    ensureAddress(config.address, 'jobRegistry.address'),
+    signer
+  );
+
+  const feePct = parsePercent(config.feePct, 'jobRegistry.feePct');
+  if (feePct !== undefined) {
+    const current = await jobRegistry.feePct();
+    if (current !== feePct) {
+      actions.push({
+        contract: jobRegistry,
+        method: 'setFeePct',
+        args: [feePct],
+        description: 'Update JobRegistry protocol fee percentage',
+        current: formatPercent(current),
+        desired: formatPercent(feePct),
+      });
+    } else if (!options.quiet) {
+      console.log(`JobRegistry feePct already ${formatPercent(current)}`);
+    }
+  }
+
+  const validatorRewardPct = parsePercent(
+    config.validatorRewardPct,
+    'jobRegistry.validatorRewardPct'
+  );
+  if (validatorRewardPct !== undefined) {
+    const current = await jobRegistry.validatorRewardPct();
+    if (current !== validatorRewardPct) {
+      actions.push({
+        contract: jobRegistry,
+        method: 'setValidatorRewardPct',
+        args: [validatorRewardPct],
+        description: 'Update validator reward percentage',
+        current: formatPercent(current),
+        desired: formatPercent(validatorRewardPct),
+      });
+    } else if (!options.quiet) {
+      console.log(
+        `JobRegistry validatorRewardPct already ${formatPercent(current)}`
+      );
+    }
+  }
+
+  const treasury = normaliseOptionalAddress(config.treasury);
+  if (treasury !== undefined) {
+    const current = await jobRegistry.treasury();
+    if (!sameAddress(current, treasury)) {
+      actions.push({
+        contract: jobRegistry,
+        method: 'setTreasury',
+        args: [treasury],
+        description: 'Set JobRegistry treasury address',
+        current: formatAddress(current),
+        desired: formatAddress(treasury),
+      });
+    } else if (!options.quiet) {
+      console.log(`JobRegistry treasury already ${formatAddress(current)}`);
+    }
+  }
+
+  const jobStake = parseTokenAmount(
+    config.jobStakeTokens,
+    'jobRegistry.jobStakeTokens'
+  );
+  if (jobStake !== undefined) {
+    const current = await jobRegistry.jobStake();
+    if (current !== jobStake) {
+      actions.push({
+        contract: jobRegistry,
+        method: 'setJobStake',
+        args: [jobStake],
+        description: 'Update per-job stake requirement',
+        current: formatTokenAmount(current),
+        desired: formatTokenAmount(jobStake),
+      });
+    } else if (!options.quiet) {
+      console.log(`JobRegistry jobStake already ${formatTokenAmount(current)}`);
+    }
+  }
+
+  const minAgentStake = parseTokenAmount(
+    config.minAgentStakeTokens,
+    'jobRegistry.minAgentStakeTokens'
+  );
+  if (minAgentStake !== undefined) {
+    const current = await jobRegistry.minAgentStake();
+    if (current !== minAgentStake) {
+      actions.push({
+        contract: jobRegistry,
+        method: 'setMinAgentStake',
+        args: [minAgentStake],
+        description: 'Update minimum agent stake',
+        current: formatTokenAmount(current),
+        desired: formatTokenAmount(minAgentStake),
+      });
+    } else if (!options.quiet) {
+      console.log(
+        `JobRegistry minAgentStake already ${formatTokenAmount(current)}`
+      );
+    }
+  }
+
+  const maxJobReward = parseTokenAmount(
+    config.maxJobRewardTokens,
+    'jobRegistry.maxJobRewardTokens'
+  );
+  if (maxJobReward !== undefined) {
+    const current = await jobRegistry.maxJobReward();
+    if (current !== maxJobReward) {
+      actions.push({
+        contract: jobRegistry,
+        method: 'setMaxJobReward',
+        args: [maxJobReward],
+        description: 'Update maximum job reward',
+        current: formatTokenAmount(current),
+        desired: formatTokenAmount(maxJobReward),
+      });
+    } else if (!options.quiet) {
+      console.log(
+        `JobRegistry maxJobReward already ${formatTokenAmount(current)}`
+      );
+    }
+  }
+
+  const maxJobDuration = parseInteger(
+    config.maxJobDurationSeconds,
+    'jobRegistry.maxJobDurationSeconds'
+  );
+  if (maxJobDuration !== undefined) {
+    const current = await jobRegistry.maxJobDuration();
+    if (current !== maxJobDuration) {
+      actions.push({
+        contract: jobRegistry,
+        method: 'setJobDurationLimit',
+        args: [maxJobDuration],
+        description: 'Update maximum job duration',
+        current: formatSeconds(current),
+        desired: formatSeconds(maxJobDuration),
+      });
+    } else if (!options.quiet) {
+      console.log(
+        `JobRegistry maxJobDuration already ${formatSeconds(current)}`
+      );
+    }
+  }
+
+  const maxActiveJobs = parseInteger(
+    config.maxActiveJobsPerAgent,
+    'jobRegistry.maxActiveJobsPerAgent'
+  );
+  if (maxActiveJobs !== undefined) {
+    const current = await jobRegistry.maxActiveJobsPerAgent();
+    if (current !== maxActiveJobs) {
+      actions.push({
+        contract: jobRegistry,
+        method: 'setMaxActiveJobsPerAgent',
+        args: [maxActiveJobs],
+        description: 'Update maximum concurrent jobs per agent',
+        current: current.toString(),
+        desired: maxActiveJobs.toString(),
+      });
+    } else if (!options.quiet) {
+      console.log(
+        `JobRegistry maxActiveJobsPerAgent already ${current.toString()}`
+      );
+    }
+  }
+
+  const expirationGrace = parseInteger(
+    config.expirationGracePeriodSeconds,
+    'jobRegistry.expirationGracePeriodSeconds'
+  );
+  if (expirationGrace !== undefined) {
+    const current = await jobRegistry.expirationGracePeriod();
+    if (current !== expirationGrace) {
+      actions.push({
+        contract: jobRegistry,
+        method: 'setExpirationGracePeriod',
+        args: [expirationGrace],
+        description: 'Update expiration grace period',
+        current: formatSeconds(current),
+        desired: formatSeconds(expirationGrace),
+      });
+    } else if (!options.quiet) {
+      console.log(
+        `JobRegistry expirationGracePeriod already ${formatSeconds(current)}`
+      );
+    }
+  }
+
+  const feePool = normaliseOptionalAddress(config.feePool);
+  if (feePool !== undefined) {
+    const current = await jobRegistry.feePool();
+    if (!sameAddress(current, feePool)) {
+      actions.push({
+        contract: jobRegistry,
+        method: 'setFeePool',
+        args: [feePool],
+        description: 'Wire JobRegistry to FeePool',
+        current: formatAddress(current),
+        desired: formatAddress(feePool),
+      });
+    } else if (!options.quiet) {
+      console.log(`JobRegistry feePool already ${formatAddress(current)}`);
+    }
+  }
+
+  const taxPolicy = normaliseOptionalAddress(config.taxPolicy);
+  if (taxPolicy !== undefined) {
+    const current = await jobRegistry.taxPolicy();
+    if (!sameAddress(current, taxPolicy)) {
+      actions.push({
+        contract: jobRegistry,
+        method: 'setTaxPolicy',
+        args: [taxPolicy],
+        description: 'Set JobRegistry tax policy reference',
+        current: formatAddress(current),
+        desired: formatAddress(taxPolicy),
+      });
+    } else if (!options.quiet) {
+      console.log(`JobRegistry taxPolicy already ${formatAddress(current)}`);
+    }
+  }
+
+  return actions;
+}
+
+async function planStakeManagerActions(
+  signer: Signer,
+  config: StakeManagerConfig,
+  options: CliOptions
+): Promise<PlannedAction[]> {
+  const actions: PlannedAction[] = [];
+  const stakeManager = await connectContract(
+    'StakeManager',
+    ensureAddress(config.address, 'stakeManager.address'),
+    signer
+  );
+
+  const minStake = parseTokenAmount(
+    config.minStakeTokens,
+    'stakeManager.minStakeTokens'
+  );
+  if (minStake !== undefined) {
+    const current = await stakeManager.minStake();
+    if (current !== minStake) {
+      actions.push({
+        contract: stakeManager,
+        method: 'setMinStake',
+        args: [minStake],
+        description: 'Update StakeManager minimum stake',
+        current: formatTokenAmount(current),
+        desired: formatTokenAmount(minStake),
+      });
+    } else if (!options.quiet) {
+      console.log(
+        `StakeManager minStake already ${formatTokenAmount(current)}`
+      );
+    }
+  }
+
+  const employerSlashPct = parsePercent(
+    config.employerSlashPct,
+    'stakeManager.employerSlashPct'
+  );
+  const treasurySlashPct = parsePercent(
+    config.treasurySlashPct,
+    'stakeManager.treasurySlashPct'
+  );
+  if (employerSlashPct !== undefined || treasurySlashPct !== undefined) {
+    const currentEmployer = await stakeManager.employerSlashPct();
+    const currentTreasury = await stakeManager.treasurySlashPct();
+    const desiredEmployer = employerSlashPct ?? currentEmployer;
+    const desiredTreasury = treasurySlashPct ?? currentTreasury;
+    if (
+      currentEmployer !== desiredEmployer ||
+      currentTreasury !== desiredTreasury
+    ) {
+      actions.push({
+        contract: stakeManager,
+        method: 'setSlashingPercentages',
+        args: [desiredEmployer, desiredTreasury],
+        description: 'Update StakeManager slashing percentages',
+        current: `${formatPercent(currentEmployer)} employer / ${formatPercent(
+          currentTreasury
+        )} treasury`,
+        desired: `${formatPercent(desiredEmployer)} employer / ${formatPercent(
+          desiredTreasury
+        )} treasury`,
+      });
+    } else if (!options.quiet) {
+      console.log(
+        `StakeManager slashing percentages already ${formatPercent(
+          currentEmployer
+        )} employer / ${formatPercent(currentTreasury)} treasury`
+      );
+    }
+  }
+
+  const stakeTreasury = normaliseOptionalAddress(config.treasury);
+  if (stakeTreasury !== undefined) {
+    const current = await stakeManager.treasury();
+    if (!sameAddress(current, stakeTreasury)) {
+      actions.push({
+        contract: stakeManager,
+        method: 'setTreasury',
+        args: [stakeTreasury],
+        description: 'Set StakeManager treasury',
+        current: formatAddress(current),
+        desired: formatAddress(stakeTreasury),
+      });
+    } else if (!options.quiet) {
+      console.log(`StakeManager treasury already ${formatAddress(current)}`);
+    }
+  }
+
+  if (Array.isArray(config.treasuryAllowlist)) {
+    for (const update of config.treasuryAllowlist) {
+      const treasuryAddress = ensureAddress(
+        update.address,
+        'stakeManager.treasuryAllowlist.address'
+      );
+      const desired = Boolean(update.allowed);
+      const current = await stakeManager.treasuryAllowlist(treasuryAddress);
+      if (current !== desired) {
+        actions.push({
+          contract: stakeManager,
+          method: 'setTreasuryAllowlist',
+          args: [treasuryAddress, desired],
+          description: `Update StakeManager treasury allowlist for ${treasuryAddress}`,
+          current: current ? 'allowed' : 'blocked',
+          desired: desired ? 'allowed' : 'blocked',
+        });
+      } else if (!options.quiet) {
+        console.log(
+          `StakeManager treasury allowlist already ${
+            desired ? 'allows' : 'blocks'
+          } ${treasuryAddress}`
+        );
+      }
+    }
+  }
+
+  const feePct = parsePercent(config.feePct, 'stakeManager.feePct');
+  if (feePct !== undefined) {
+    const current = await stakeManager.feePct();
+    if (current !== feePct) {
+      actions.push({
+        contract: stakeManager,
+        method: 'setFeePct',
+        args: [feePct],
+        description: 'Update StakeManager fee percentage',
+        current: formatPercent(current),
+        desired: formatPercent(feePct),
+      });
+    } else if (!options.quiet) {
+      console.log(`StakeManager feePct already ${formatPercent(current)}`);
+    }
+  }
+
+  const burnPct = parsePercent(config.burnPct, 'stakeManager.burnPct');
+  if (burnPct !== undefined) {
+    const current = await stakeManager.burnPct();
+    if (current !== burnPct) {
+      actions.push({
+        contract: stakeManager,
+        method: 'setBurnPct',
+        args: [burnPct],
+        description: 'Update StakeManager burn percentage',
+        current: formatPercent(current),
+        desired: formatPercent(burnPct),
+      });
+    } else if (!options.quiet) {
+      console.log(`StakeManager burnPct already ${formatPercent(current)}`);
+    }
+  }
+
+  const validatorRewardPct = parsePercent(
+    config.validatorRewardPct,
+    'stakeManager.validatorRewardPct'
+  );
+  if (validatorRewardPct !== undefined) {
+    const current = await stakeManager.validatorRewardPct();
+    if (current !== validatorRewardPct) {
+      actions.push({
+        contract: stakeManager,
+        method: 'setValidatorRewardPct',
+        args: [validatorRewardPct],
+        description: 'Update StakeManager validator reward percentage',
+        current: formatPercent(current),
+        desired: formatPercent(validatorRewardPct),
+      });
+    } else if (!options.quiet) {
+      console.log(
+        `StakeManager validatorRewardPct already ${formatPercent(current)}`
+      );
+    }
+  }
+
+  const unbondingPeriod = parseInteger(
+    config.unbondingPeriodSeconds,
+    'stakeManager.unbondingPeriodSeconds'
+  );
+  if (unbondingPeriod !== undefined) {
+    const current = await stakeManager.unbondingPeriod();
+    if (current !== unbondingPeriod) {
+      actions.push({
+        contract: stakeManager,
+        method: 'setUnbondingPeriod',
+        args: [unbondingPeriod],
+        description: 'Update StakeManager unbonding period',
+        current: formatSeconds(current),
+        desired: formatSeconds(unbondingPeriod),
+      });
+    } else if (!options.quiet) {
+      console.log(
+        `StakeManager unbondingPeriod already ${formatSeconds(current)}`
+      );
+    }
+  }
+
+  const maxStakePerAddress = parseTokenAmount(
+    config.maxStakePerAddressTokens,
+    'stakeManager.maxStakePerAddressTokens'
+  );
+  if (maxStakePerAddress !== undefined) {
+    const current = await stakeManager.maxStakePerAddress();
+    if (current !== maxStakePerAddress) {
+      actions.push({
+        contract: stakeManager,
+        method: 'setMaxStakePerAddress',
+        args: [maxStakePerAddress],
+        description: 'Update StakeManager max stake per address',
+        current: formatTokenAmount(current),
+        desired: formatTokenAmount(maxStakePerAddress),
+      });
+    } else if (!options.quiet) {
+      console.log(
+        `StakeManager maxStakePerAddress already ${formatTokenAmount(current)}`
+      );
+    }
+  }
+
+  if (config.stakeRecommendations) {
+    const minRec = parseTokenAmount(
+      config.stakeRecommendations.minTokens,
+      'stakeManager.stakeRecommendations.minTokens'
+    );
+    const maxRec = parseTokenAmount(
+      config.stakeRecommendations.maxTokens,
+      'stakeManager.stakeRecommendations.maxTokens'
+    );
+    if (minRec !== undefined || maxRec !== undefined) {
+      const currentMin = await stakeManager.minStake();
+      const currentMax = await stakeManager.maxStakePerAddress();
+      const desiredMin = minRec ?? currentMin;
+      const desiredMax = maxRec ?? currentMax;
+      if (currentMin !== desiredMin || currentMax !== desiredMax) {
+        actions.push({
+          contract: stakeManager,
+          method: 'setStakeRecommendations',
+          args: [desiredMin, desiredMax],
+          description: 'Update StakeManager stake recommendations',
+          current: `${formatTokenAmount(currentMin)} min / ${formatTokenAmount(
+            currentMax
+          )} max`,
+          desired: `${formatTokenAmount(desiredMin)} min / ${formatTokenAmount(
+            desiredMax
+          )} max`,
+        });
+      } else if (!options.quiet) {
+        console.log(
+          `StakeManager stake recommendations already ${formatTokenAmount(
+            currentMin
+          )} min / ${formatTokenAmount(currentMax)} max`
+        );
+      }
+    }
+  }
+
+  return actions;
+}
+
+async function planFeePoolActions(
+  signer: Signer,
+  config: FeePoolConfig,
+  options: CliOptions
+): Promise<PlannedAction[]> {
+  const actions: PlannedAction[] = [];
+  const feePool = await connectContract(
+    'FeePool',
+    ensureAddress(config.address, 'feePool.address'),
+    signer
+  );
+
+  const burnPct = parsePercent(config.burnPct, 'feePool.burnPct');
+  if (burnPct !== undefined) {
+    const current = await feePool.burnPct();
+    if (current !== burnPct) {
+      actions.push({
+        contract: feePool,
+        method: 'setBurnPct',
+        args: [burnPct],
+        description: 'Update FeePool burn percentage',
+        current: formatPercent(current),
+        desired: formatPercent(burnPct),
+      });
+    } else if (!options.quiet) {
+      console.log(`FeePool burnPct already ${formatPercent(current)}`);
+    }
+  }
+
+  const treasury = normaliseOptionalAddress(config.treasury);
+  if (treasury !== undefined) {
+    const current = await feePool.treasury();
+    if (!sameAddress(current, treasury)) {
+      actions.push({
+        contract: feePool,
+        method: 'setTreasury',
+        args: [treasury],
+        description: 'Update FeePool treasury',
+        current: formatAddress(current),
+        desired: formatAddress(treasury),
+      });
+    } else if (!options.quiet) {
+      console.log(`FeePool treasury already ${formatAddress(current)}`);
+    }
+  }
+
+  if (Array.isArray(config.treasuryAllowlist)) {
+    for (const update of config.treasuryAllowlist) {
+      const treasuryAddress = ensureAddress(
+        update.address,
+        'feePool.treasuryAllowlist.address'
+      );
+      const desired = Boolean(update.allowed);
+      const current = await feePool.treasuryAllowlist(treasuryAddress);
+      if (current !== desired) {
+        actions.push({
+          contract: feePool,
+          method: 'setTreasuryAllowlist',
+          args: [treasuryAddress, desired],
+          description: `Update FeePool treasury allowlist for ${treasuryAddress}`,
+          current: current ? 'allowed' : 'blocked',
+          desired: desired ? 'allowed' : 'blocked',
+        });
+      } else if (!options.quiet) {
+        console.log(
+          `FeePool treasury allowlist already ${
+            desired ? 'allows' : 'blocks'
+          } ${treasuryAddress}`
+        );
+      }
+    }
+  }
+
+  return actions;
+}
+
+async function planTaxPolicyActions(
+  signer: Signer,
+  config: TaxPolicyConfig,
+  options: CliOptions
+): Promise<PlannedAction[]> {
+  const actions: PlannedAction[] = [];
+  const taxPolicy = await connectContract(
+    'TaxPolicy',
+    ensureAddress(config.address, 'taxPolicy.address'),
+    signer
+  );
+
+  const desiredPolicy =
+    config.policy ||
+    (config.policyURI && config.acknowledgement
+      ? { uri: config.policyURI, acknowledgement: config.acknowledgement }
+      : undefined);
+
+  if (desiredPolicy) {
+    const currentUri: string = await taxPolicy.policyURI();
+    const currentAck: string = await taxPolicy.acknowledgement();
+    if (
+      currentUri !== desiredPolicy.uri ||
+      currentAck !== desiredPolicy.acknowledgement
+    ) {
+      actions.push({
+        contract: taxPolicy,
+        method: 'setPolicy',
+        args: [desiredPolicy.uri, desiredPolicy.acknowledgement],
+        description: 'Update tax policy URI and acknowledgement text',
+        current: `${currentUri} | ${currentAck}`,
+        desired: `${desiredPolicy.uri} | ${desiredPolicy.acknowledgement}`,
+      });
+    } else if (!options.quiet) {
+      console.log('TaxPolicy URI and acknowledgement already match config');
+    }
+  } else {
+    if (config.policyURI) {
+      const currentUri: string = await taxPolicy.policyURI();
+      if (currentUri !== config.policyURI) {
+        actions.push({
+          contract: taxPolicy,
+          method: 'setPolicyURI',
+          args: [config.policyURI],
+          description: 'Update tax policy URI',
+          current: currentUri,
+          desired: config.policyURI,
+        });
+      } else if (!options.quiet) {
+        console.log('TaxPolicy URI already matches config');
+      }
+    }
+    if (config.acknowledgement) {
+      const currentAck: string = await taxPolicy.acknowledgement();
+      if (currentAck !== config.acknowledgement) {
+        actions.push({
+          contract: taxPolicy,
+          method: 'setAcknowledgement',
+          args: [config.acknowledgement],
+          description: 'Update tax acknowledgement text',
+          current: currentAck,
+          desired: config.acknowledgement,
+        });
+      } else if (!options.quiet) {
+        console.log('TaxPolicy acknowledgement already matches config');
+      }
+    }
+  }
+
+  if (Array.isArray(config.acknowledgers)) {
+    for (const update of config.acknowledgers) {
+      const address = ensureAddress(
+        update.address,
+        'taxPolicy.acknowledgers.address'
+      );
+      const desired = Boolean(update.allowed);
+      const filter = taxPolicy.filters?.AcknowledgerUpdated?.(address, null);
+      let current = false;
+      if (filter) {
+        try {
+          const events = await taxPolicy.queryFilter(filter, 0, 'latest');
+          const last = events.at(-1);
+          if (
+            last &&
+            Array.isArray(last.args) &&
+            typeof last.args[1] === 'boolean'
+          ) {
+            current = last.args[1];
+          }
+        } catch (eventError) {
+          console.warn(
+            `Warning: could not query acknowledger history for ${address}: ${
+              (eventError as Error).message
+            }`
+          );
+        }
+      }
+      if (current !== desired) {
+        actions.push({
+          contract: taxPolicy,
+          method: 'setAcknowledger',
+          args: [address, desired],
+          description: `Update tax acknowledger permission for ${address}`,
+          current: current ? 'allowed' : 'blocked',
+          desired: desired ? 'allowed' : 'blocked',
+        });
+      } else if (!options.quiet) {
+        console.log(
+          `TaxPolicy acknowledger already ${
+            desired ? 'allows' : 'blocks'
+          } ${address}`
+        );
+      }
+    }
+  }
+
+  return actions;
+}
+
+async function executeActions(actions: PlannedAction[], execute: boolean) {
+  if (actions.length === 0) {
+    console.log('No changes required. All parameters match the configuration.');
+    return;
+  }
+
+  console.log(`Planned ${actions.length} action(s) on network ${network.name}`);
+  for (const [index, action] of actions.entries()) {
+    console.log(`\n[${index + 1}/${actions.length}] ${action.description}`);
+    if (action.current !== undefined) {
+      console.log(`  Current: ${action.current}`);
+    }
+    if (action.desired !== undefined) {
+      console.log(`  Desired: ${action.desired}`);
+    }
+    console.log(
+      `  Method: ${action.contract.target}.${action.method}(${action.args
+        .map((arg) =>
+          typeof arg === 'bigint'
+            ? arg.toString()
+            : typeof arg === 'string'
+            ? arg
+            : typeof arg === 'boolean'
+            ? arg
+              ? 'true'
+              : 'false'
+            : JSON.stringify(arg)
+        )
+        .join(', ')})`
+    );
+  }
+
+  if (!execute) {
+    console.log(
+      '\nDry run complete. Re-run with --execute to apply these updates.'
+    );
+    return;
+  }
+
+  console.log('\nExecuting actions...');
+  for (const [index, action] of actions.entries()) {
+    console.log(
+      `Sending ${index + 1}/${actions.length}: ${action.description}`
+    );
+    const tx = await (action.contract as any)[action.method](...action.args);
+    console.log(`  Tx hash: ${tx.hash}`);
+    await tx.wait(1);
+    console.log('  Confirmed');
+  }
+  console.log('\nAll updates confirmed.');
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const config = loadConfig(options.configPath);
+  const signer = (await ethers.getSigners())[0];
+  if (!signer) {
+    throw new Error(
+      'No signer available. Check MAINNET_PRIVATE_KEY or selected network credentials.'
+    );
+  }
+  const actions: PlannedAction[] = [];
+
+  if (config.jobRegistry) {
+    actions.push(
+      ...(await planJobRegistryActions(signer, config.jobRegistry, options))
+    );
+  }
+  if (config.stakeManager) {
+    actions.push(
+      ...(await planStakeManagerActions(signer, config.stakeManager, options))
+    );
+  }
+  if (config.feePool) {
+    actions.push(
+      ...(await planFeePoolActions(signer, config.feePool, options))
+    );
+  }
+  if (config.taxPolicy) {
+    actions.push(
+      ...(await planTaxPolicyActions(signer, config.taxPolicy, options))
+    );
+  }
+
+  await executeActions(actions, options.execute);
+}
+
+main().catch((error) => {
+  console.error('Governance update failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Hardhat governance update script with dry-run support to adjust JobRegistry, StakeManager, FeePool, and TaxPolicy parameters from a JSON plan
- document a non-technical Truffle mainnet deployment playbook and link it from the README alongside the new helper workflow
- publish a governance update config template and npm alias to simplify owner operations

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d54165f7808333b645ba8fd5f25e52